### PR TITLE
Use canonical path in root.path

### DIFF
--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryFrom, io::Write, path::Path};
+use std::{collections::HashMap, convert::TryFrom, io::Write, path::{Path, PathBuf}};
 
 use crate::core::common::{Result, Error, ErrorType};
 
@@ -19,7 +19,7 @@ pub struct State {
     pub id: String,
     pub status: Status,
     pub pid: u64,
-    pub bundle: String,
+    pub bundle: PathBuf,
     pub annotations: Option<HashMap<String, String>>,
 }
 
@@ -32,7 +32,7 @@ impl State {
             id: id.clone(),
             pid: pid,
             status: Status::Creating,
-            bundle: bundle.clone(),
+            bundle: Path::new(bundle).canonicalize().unwrap(),
             annotations: Some(HashMap::<String, String>::new()),
         }
     }
@@ -45,7 +45,7 @@ impl State {
             .create(true)
             .open(root_path.join("state.json"))
             .map_err(|err| Error {
-                msg: err.to_string(),
+                msg: format!("save state failed {} for {:?}", err, root_path),
                 err_type: ErrorType::Container,
             })?;
         state_file

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -103,11 +103,9 @@ impl PtySocket {
             socket_fd,
             &SockAddr::Unix(UnixAddr::new(console_socket_path.as_str()).unwrap()),
         )
-        .map_err(|err| {
-            Error {
-                msg: format!("error opening console-socket {}", err),
-                err_type: ErrorType::Runtime,
-            }
+        .map_err(|err| Error {
+            msg: fromat!("error connecting pty {}", err),
+            err_type: ErrorType::Runtime,
         })?;
 
         Ok(PtySocket {

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -104,7 +104,7 @@ impl PtySocket {
             &SockAddr::Unix(UnixAddr::new(console_socket_path.as_str()).unwrap()),
         )
         .map_err(|err| Error {
-            msg: fromat!("error connecting pty {}", err),
+            msg: format!("error connecting pty {}", err),
             err_type: ErrorType::Runtime,
         })?;
 


### PR DESCRIPTION
- canonical bundle path in root.path
- improved logging messages